### PR TITLE
Calculate Holm-adjusted p-values for pairwise error rates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 scripts/.Rhistory
+.Rproj.user

--- a/scripts/CompareAU.R
+++ b/scripts/CompareAU.R
@@ -364,7 +364,7 @@ comau_NA_all <- bind_rows(comau1[, c("treatment", "participant_id", "answer")],
                           comau3[, c("treatment", "participant_id", "answer")], 
                           comau4[, c("treatment", "participant_id", "answer")])
 
-comau_NA_all$answer <- factor(as.character(comau_NA_all$answer))
+# comau_NA_all$answer <- factor(as.character(comau_NA_all$answer))
 comau_NA_all$treatment <- factor(comau_NA_all$treatment, levels = treatments)
 
 cqtest <- cochran_qtest(comau_NA_all, answer ~ treatment | participant_id)
@@ -406,11 +406,26 @@ na_pairwise_effect_ci <- function(NA_all, two_treatments) {
   
 }
 
-na_pairwise_effect_ci(comau_NA_all, c("None", "StLO"))
-na_pairwise_effect_ci(comau_NA_all, c("None", "StLG"))
+na_pairwise_effect_ci(comau_NA_all, c("None", "StLO")) 
+na_pairwise_effect_ci(comau_NA_all, c("None", "StLG")) 
 na_pairwise_effect_ci(comau_NA_all, c("None", "SeLG"))
 na_pairwise_effect_ci(comau_NA_all, c("StLO", "StLG"))
 na_pairwise_effect_ci(comau_NA_all, c("StLO", "SeLG"))
+p_none_stlo <- na_pairwise_effect_ci(comau_NA_all, c("None", "StLO"))$p.value
+p_none_stlg <- na_pairwise_effect_ci(comau_NA_all, c("None", "StLG"))$p.value
+p_none_selg <- na_pairwise_effect_ci(comau_NA_all, c("None", "SeLG"))$p.value
+p_stlo_stlg <- na_pairwise_effect_ci(comau_NA_all, c("StLO", "StLG"))$p.value
+p_stlo_selg <- na_pairwise_effect_ci(comau_NA_all, c("StLO", "SeLG"))$p.value
+p_stlg_selg <- na_pairwise_effect_ci(comau_NA_all, c("StLG", "SeLG"))$p.value
+na_pairwise_effect_adj <-
+  tribble(~group1, ~group2, ~p,
+          "None", "StLO", p_none_stlo,
+          "None", "StLG", p_none_stlg,
+          "None", "SeLG", p_none_selg,
+          "StLO", "StLG", p_stlo_stlg,
+          "StLO", "SeLG", p_stlo_selg,
+          "StLG", "SeLG", p_stlg_selg) |>
+  mutate(p_adj = p.adjust(p, method = "holm"))
 
 ###################################
 ######      Combine plots     #####

--- a/scripts/DetectZone.R
+++ b/scripts/DetectZone.R
@@ -322,7 +322,7 @@ dczo_NA_all <- bind_rows(dczo1[, c("treatment", "participant_id", "answer")],
                          dczo3[, c("treatment", "participant_id", "answer")], 
                          dczo4[, c("treatment", "participant_id", "answer")])
 
-dczo_NA_all$answer <- factor(as.character(dczo_NA_all$answer))
+# dczo_NA_all$answer <- factor(as.character(dczo_NA_all$answer))
 dczo_NA_all$treatment <- factor(dczo_NA_all$treatment, levels = treatments)
 
 cqtest <- cochran_qtest(dczo_NA_all, answer ~ treatment | participant_id)
@@ -330,22 +330,53 @@ cqtest$p.value <- cqtest$p
 
 pbar_title <- chi2_and_main_p(cqtest)
 
-pbar <- get_NA_barplot(dczo_NA_count, pbar_title)
+# pbar <- get_NA_barplot(dczo_NA_count, pbar_title)
 
 dczo_pairwise_mcnemar <- pairwise_mcnemar_test(dczo_NA_all, 
                                                answer ~ treatment | participant_id,
                                                p.adjust.method = "holm") %>%
   filter(!is.nan(p))
 
-pbar <- pbar + stat_pvalue_manual(dczo_pairwise_mcnemar,
-                                  label = "p.adj.signif",
-                                  hide.ns = TRUE,
-                                  y.position = c(50))
+# pbar <- pbar + stat_pvalue_manual(dczo_pairwise_mcnemar,
+#                                   label = "p.adj.signif",
+#                                   hide.ns = TRUE,
+#                                   y.position = c(50))
 
 
 # Confidence Interval for NA pairwise results
-
+# Function to get pairwise CIs for NA analysis
+na_pairwise_effect_ci <- function(NA_all, two_treatments) {
+  
+  sbset <- NA_all[NA_all$treatment %in% two_treatments, ]
+  sbset$answer <- as.logical(sbset$answer)
+  sbset <- pivot_wider(sbset, names_from = "treatment",
+                       values_from = "answer")
+  
+  tble = matrix(0, 2, 2)
+  tble[1, 1] <- sum(!sbset[,two_treatments[1]] & !sbset[,two_treatments[2]])
+  tble[1, 2] <- sum(!sbset[,two_treatments[1]] & sbset[,two_treatments[2]])
+  tble[2, 1] <- sum(sbset[,two_treatments[1]] & !sbset[,two_treatments[2]])
+  tble[2, 2] <- sum(sbset[,two_treatments[1]] & sbset[,two_treatments[2]])
+  
+  mcnemar.exact(tble)
+  
+}
 na_pairwise_effect_ci(dczo_NA_all, c("None", "SeLG"))
+p_none_stlo <- na_pairwise_effect_ci(dczo_NA_all, c("None", "StLO"))$p.value
+p_none_stlg <- na_pairwise_effect_ci(dczo_NA_all, c("None", "StLG"))$p.value
+p_none_selg <- na_pairwise_effect_ci(dczo_NA_all, c("None", "SeLG"))$p.value
+p_stlo_stlg <- na_pairwise_effect_ci(dczo_NA_all, c("StLO", "StLG"))$p.value
+p_stlo_selg <- na_pairwise_effect_ci(dczo_NA_all, c("StLO", "SeLG"))$p.value
+p_stlg_selg <- na_pairwise_effect_ci(dczo_NA_all, c("StLG", "SeLG"))$p.value
+na_pairwise_effect_adj <-
+  tribble(~group1, ~group2, ~p,
+          "None", "StLO", p_none_stlo,
+          "None", "StLG", p_none_stlg,
+          "None", "SeLG", p_none_selg,
+          "StLO", "StLG", p_stlo_stlg,
+          "StLO", "SeLG", p_stlo_selg,
+          "StLG", "SeLG", p_stlg_selg) |>
+  mutate(p_adj = p.adjust(p, method = "holm"))
 
 ###################################
 ######      Combine plots     #####
@@ -358,11 +389,11 @@ title <-
              size = 15) +
   theme(plot.background = element_rect(fill = "#e6e6e6", color = NA)) 
 
-bottom_row <- plot_grid(pall, tall, pbar, ncol = 3, rel_heights = c(3/10, 4/10, 4/10))
-pcombined <- plot_grid(title,
-                       bottom_row,
-                       nrow = 2,
-                       rel_heights = c(0.12, 1))
+# bottom_row <- plot_grid(pall, tall, pbar, ncol = 3, rel_heights = c(3/10, 4/10, 4/10))
+# pcombined <- plot_grid(title,
+#                        bottom_row,
+#                        nrow = 2,
+#                        rel_heights = c(0.12, 1))
 
 #saveRDS(pcombined, file = "../rdata/Combined_DCZo.rds")
 #ggsave("Combined_DCZo.pdf", pcombined, path = "../plots/", width = 6, height = 4)
@@ -377,7 +408,7 @@ dczo_all %>%
   pivot_wider(names_from = Treatment, values_from = Normal) %>%
   summary
 
-sum(dczo_NA_count / 176) * 100
+# sum(dczo_NA_count / 176) * 100
 
 dczo_NA_all %>%
   group_by(treatment) %>%

--- a/scripts/EstimateAU.R
+++ b/scripts/EstimateAU.R
@@ -238,20 +238,20 @@ cqtest$p.value <- cqtest$p
 
 
 pbar_title <- chi2_and_main_p(cqtest)
-pbar <- get_NA_barplot(estau_NA, pbar_title)
+# pbar <- get_NA_barplot(estau_NA, pbar_title)
 
 # Plot significant p-values
 
-estau_pairwise_mcnemar <- pairwise_mcnemar_test(estau_NA_all, 
+estau_pairwise_mcnemar <- pairwise_mcnemar_test(estau_NA_all,
                                                 answer ~ treatment | participant_id,
                                                 p.adjust.method = "holm") %>%
   filter(!is.nan(p))
 
 
-pbar <- pbar + stat_pvalue_manual(estau_pairwise_mcnemar,
-                                  label = "p.adj.signif",
-                                  hide.ns = TRUE,
-                                  y.position = c(57, 50, 71, 64))
+# pbar <- pbar + stat_pvalue_manual(estau_pairwise_mcnemar,
+#                                   label = "p.adj.signif",
+#                                   hide.ns = TRUE,
+#                                   y.position = c(57, 50, 71, 64))
 
 # Confidence Interval for NA pairwise results
 
@@ -277,6 +277,21 @@ na_pairwise_effect_ci(estau_NA_all, c("None", "StLG"))
 na_pairwise_effect_ci(estau_NA_all, c("None", "SeLG"))
 na_pairwise_effect_ci(estau_NA_all, c("StLO", "StLG"))
 na_pairwise_effect_ci(estau_NA_all, c("StLO", "SeLG"))
+p_none_stlo <- na_pairwise_effect_ci(estau_NA_all, c("None", "StLO"))$p.value
+p_none_stlg <- na_pairwise_effect_ci(estau_NA_all, c("None", "StLG"))$p.value
+p_none_selg <- na_pairwise_effect_ci(estau_NA_all, c("None", "SeLG"))$p.value
+p_stlo_stlg <- na_pairwise_effect_ci(estau_NA_all, c("StLO", "StLG"))$p.value
+p_stlo_selg <- na_pairwise_effect_ci(estau_NA_all, c("StLO", "SeLG"))$p.value
+p_stlg_selg <- na_pairwise_effect_ci(estau_NA_all, c("StLG", "SeLG"))$p.value
+na_pairwise_effect_adj <-
+  tribble(~group1, ~group2, ~p,
+          "None", "StLO", p_none_stlo,
+          "None", "StLG", p_none_stlg,
+          "None", "SeLG", p_none_selg,
+          "StLO", "StLG", p_stlo_stlg,
+          "StLO", "SeLG", p_stlo_selg,
+          "StLG", "SeLG", p_stlg_selg) |>
+  mutate(p_adj = p.adjust(p, method = "holm"))
 
 ###################################
 ######      Combine plots     #####
@@ -288,11 +303,11 @@ title <-
              size = 15) +
   theme(plot.background = element_rect(fill = "#e6e6e6", color = NA)) 
 
-bottom_row <- plot_grid(pall, tall, pbar, ncol = 3, rel_heights = c(3/9, 3/9, 3/9))
-pcombined <- plot_grid(title,
-                       bottom_row,
-                       nrow = 2,
-                       rel_heights = c(0.12, 1))
+# bottom_row <- plot_grid(pall, tall, pbar, ncol = 3, rel_heights = c(3/9, 3/9, 3/9))
+# pcombined <- plot_grid(title,
+#                        bottom_row,
+#                        nrow = 2,
+#                        rel_heights = c(0.12, 1))
 
 #saveRDS(pcombined, file = "../rdata/Combined_EstAU.rds")
 #ggsave("Combined_EstAU.pdf", pcombined, path = "../plots/", width = 6, height = 4)
@@ -307,7 +322,7 @@ estau_all %>%
   pivot_wider(names_from = Treatment, values_from = Normal) %>%
   summary
 
-sum(estau_NA / 176) * 100
+# sum(estau_NA / 176) * 100
 
 estau_NA_all %>%
   group_by(treatment) %>%

--- a/scripts/scripts.Rproj
+++ b/scripts/scripts.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX


### PR DESCRIPTION
The adjusted p-values for pairwise error rates are a little bit smaller than those from `pairwise_mcnemar_test()`. Run each script and print `na_pairwise_effect_adj` in the console to see the effect. I also had to comment out several lines of code that refer to non-existing variables.

I updated section 5 of the supplement on Overleaf.

Please check whether this change needs any updates to the figures in the main text.